### PR TITLE
feat: add dockerfile

### DIFF
--- a/.github/workflows/publish_with_latest.yml
+++ b/.github/workflows/publish_with_latest.yml
@@ -1,0 +1,21 @@
+name: Publish Image Using latest
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  push:
+    name: Publish Image using latest tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Push the image on the registry
+        uses: Ferlab-Ste-Justine/action-push-image@v2
+        with:
+          username: ${{ secrets.FERLAB_DOCKER_HUB_USER }}
+          password: ${{ secrets.FERLAB_DOCKER_HUB_TOKEN }}
+          image: ferlabcrsj/qc-pipeline-python
+          location: containers/python
+          tag_format: "latest"

--- a/.github/workflows/publish_with_semver_tag.yml
+++ b/.github/workflows/publish_with_semver_tag.yml
@@ -1,0 +1,21 @@
+name: Publish Image Using Semver Tag
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  push:
+    name: Publish Image using tags
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Push the image on the registry
+        uses: Ferlab-Ste-Justine/action-push-image@v2
+        with:
+          username: ${{ secrets.FERLAB_DOCKER_HUB_USER }}
+          password: ${{ secrets.FERLAB_DOCKER_HUB_TOKEN }}
+          image: ferlabcrsj/qc-pipeline-python
+          location: containers/python
+          tag_format: "{semver}"

--- a/.github/workflows/publish_with_sha.yml
+++ b/.github/workflows/publish_with_sha.yml
@@ -1,0 +1,21 @@
+name: Publish Image Using Sha and Timestamp
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  push:
+    name: Publish Image using commit sha and timestamp
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Push the image on the registry
+        uses: Ferlab-Ste-Justine/action-push-image@v2
+        with:
+          username: ${{ secrets.FERLAB_DOCKER_HUB_USER }}
+          password: ${{ secrets.FERLAB_DOCKER_HUB_TOKEN }}
+          image: ferlabcrsj/qc-pipeline-python
+          location: containers/python
+          tag_format: "{sha}-{timestamp}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore virtual environment directory
+venv

--- a/containers/python/Dockerfile
+++ b/containers/python/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+# Copy the requirements file
+COPY requirements_full.txt requirements.txt
+
+# Install the project dependencies
+RUN pip install -r requirements.txt
+
+# Run your application
+CMD [ "python"]

--- a/containers/python/README.md
+++ b/containers/python/README.md
@@ -1,0 +1,25 @@
+This docker image is designed to process data from various quality control tools, such as multi-qc, and generate simplified reports and alerts. 
+
+It comes pre-installed with popular Python libraries for data analysis and visualization, including matplotlib, numpy, and pandas.
+
+
+## Local Testing Commands
+
+To build it locally, you can use the following command from the project root directory:
+
+```
+docker build containers/python -t qc-pipeline-python:dev
+```
+
+
+To open a shell on a Docker container created from this image, run the following command:
+
+```
+docker run -it --rm qc-pipeline-python:dev /bin/bash
+```
+
+Since the `--rm` option is specified, the container will be automatically deleted once you exit the shell.
+
+## Update python dependencies
+
+To update the Python dependencies, you can follow the instructions provided in the [how_to_update_python_dependencies.md](how_to_update_python_dependencies.md) file.

--- a/containers/python/how_to_update_python_dependencies.md
+++ b/containers/python/how_to_update_python_dependencies.md
@@ -1,0 +1,23 @@
+To update versions in the `requirements_full.txt` file from a `requirements_minimal.txt` file containing only package names without versions, you can follow these steps:
+
+1. Create a and activate a new virtual environment using a tool like `virtualenv` or `venv`. This will ensure a clean and isolated environment for the update process.  Here is an example with venv:
+
+```
+python3 -m venv ./venv
+
+source ./venv/bin/activate
+```
+
+Make sure to use the same python version as in the dockerfile (here 3.11)
+
+2. Install the packages listed in the `requirements_minimal.txt` file using the command `pip install -r requirements_minimal.txt`. This will install the latest versions of the packages.
+
+3. Use the `pip freeze` command to generate a list of installed packages and their versions in the virtual environment:
+ `pip freeze > requirements_full.txt`.
+
+4. Test that scripts relying on this image still works.
+
+5. Deactivate the virtual environment. For venv you can simply use the command `deactivate`. 
+
+6. Make sure to commit and push your changes.
+

--- a/containers/python/requirements_full.txt
+++ b/containers/python/requirements_full.txt
@@ -1,0 +1,14 @@
+contourpy==1.2.1
+cycler==0.12.1
+fonttools==4.53.1
+kiwisolver==1.4.5
+matplotlib==3.9.1
+numpy==2.0.1
+packaging==24.1
+pandas==2.2.2
+pillow==10.4.0
+pyparsing==3.1.2
+python-dateutil==2.9.0.post0
+pytz==2024.1
+six==1.16.0
+tzdata==2024.1

--- a/containers/python/requirements_minimal.txt
+++ b/containers/python/requirements_minimal.txt
@@ -1,0 +1,3 @@
+matplotlib
+numpy
+pandas


### PR DESCRIPTION
**Description**
This pull request introduces the necessary components to create and publish a custom docker image for quality control Python scripts.

**Changes**
-Added a basic Dockerfile to build the docker image.
-Integrated standard Ferlab GitHub Actions to automatically build and publish the docker image

**Tests descrition**
- I built the image locally and open a shell on it. I checked that I was able to import the required libraries (numpy, matplotlib and pandas) in the python interpreter.
- Not covered: github actions: these are very difficult to test locally as we need a git repository. We might need to do hot fixes if they are not right. Apart from the docker image build process, it should not affect any other functionality.