### PR TITLE
Parse samplesheet into 3 input channels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ testing*
 *.pyc
 null/
 .vscode
+localTest/
+data-test/
+.nf-test.log
+.nf-test/

--- a/assets/samplesheet.csv
+++ b/assets/samplesheet.csv
@@ -1,5 +1,5 @@
 participant,sample,sex,familyId,lane,fastq_1,fastq_2,cram,crai,bam,bai,gvcf
-P001,S001,XX,f1,L001,test_data/sample1_R1.fastq.gz,test_data/sample1_R2.fastq.gz,,,,
-P001,S001,XX,f1,L002,test_data/sample1_lane2_R1.fastq.gz,test_data/sample1_lane2_R2.fastq.gz,,,,
-P002,S002,XY,f2,,,,,,test_data/sample2.bam,test_data/sample2.bam.bai,
-P003,S003,XX,f3,,,,,test_data/sample3.bam,test_data/sample3.bam.bai,test_data/sample3.gvcf.gz,test_data/sample3.gvcf.gz
+P001,S001,female,f1,L001,../data-test/test1/sample1_R1.fastq.gz,../data-test/test1/sample1_R2.fastq.gz,,,,
+P001,S001,female,f1,L002,../data-test/test1/sample1_lane2_R1.fastq.gz,../data-test/test1/sample1_lane2_R2.fastq.gz,,,,
+P002,S002,male,f2,,,,,,../data-test/test1/sample2.bam,../data-test/test1/sample2.bam.bai,
+P003,S003,female,f3,,,,,,../data-test/test1/sample3.bam,../data-test/test1/sample3.bam.bai,../data-test/test1/sample3.gvcf.gz

--- a/main.nf
+++ b/main.nf
@@ -41,7 +41,9 @@ params.fasta = getGenomeAttribute('fasta')
 workflow FERLABSTEJUSTINE_QUALITYCONTROL {
 
     take:
-    samplesheet // channel: samplesheet read in from --input
+    samplesheet_fastq // channel: samplesheet read in from --input
+    samplesheet_aln // channel: samplesheet read in from --input
+    samplesheet_gvcf // channel: samplesheet read in from --input
 
     main:
 
@@ -49,7 +51,9 @@ workflow FERLABSTEJUSTINE_QUALITYCONTROL {
     // WORKFLOW: Run pipeline
     //
     QUALITYCONTROL (
-        samplesheet
+        samplesheet_fastq,
+        samplesheet_aln,
+        samplesheet_gvcf
     )
     emit:
     multiqc_report = QUALITYCONTROL.out.multiqc_report // channel: /path/to/multiqc_report.html
@@ -79,7 +83,9 @@ workflow {
     // WORKFLOW: Run main workflow
     //
     FERLABSTEJUSTINE_QUALITYCONTROL (
-        PIPELINE_INITIALISATION.out.samplesheet
+        PIPELINE_INITIALISATION.out.samplesheet_fastq,
+        PIPELINE_INITIALISATION.out.samplesheet_aln,
+        PIPELINE_INITIALISATION.out.samplesheet_gvcf
     )
     //
     // SUBWORKFLOW: Run completion tasks

--- a/subworkflows/local/utils_nfcore_quality-control-pipeline_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_quality-control-pipeline_pipeline/main.nf
@@ -70,28 +70,31 @@ workflow PIPELINE_INITIALISATION {
     // Create channel from input file provided through params.input
     //
 
-    Channel
-        .fromList(samplesheetToList(params.input, "${projectDir}/assets/schema_input.json"))
+    ch_samplesheet = Channel
+        .fromList(samplesheetToList(input, "${projectDir}/assets/schema_input.json"))
         .map {
-            meta, fastq_1, fastq_2 ->
-                if (!fastq_2) {
-                    return [ meta.id, meta + [ single_end:true ], [ fastq_1 ] ]
-                } else {
-                    return [ meta.id, meta + [ single_end:false ], [ fastq_1, fastq_2 ] ]
-                }
-        }
-        .groupTuple()
-        .map { samplesheet ->
-            validateInputSamplesheet(samplesheet)
-        }
-        .map {
-            meta, fastqs ->
-                return [ meta, fastqs.flatten() ]
-        }
-        .set { ch_samplesheet }
+            meta, fastq_1, fastq_2, cram, crai, bam, bai, gvcf ->
+                // [meta.participant + meta.sample, [meta, fastq_1, fastq_2, cram, crai, bam, bai, gvcf]]
+                [meta, fastq_1, fastq_2, cram, crai, bam, bai, gvcf]
+            }.tap { ch_participant_sample } // save input channel
+            // .groupTuple() // group by participant_sample
+            // branch input by type by data type. fastq, bam + bai, cram + crai, or gvcf
+            .branch { meta, fastq_1, fastq_2, cram, crai, bam, bai, gvcf ->
+                fastq: fastq_1
+                    // return channel [meta, fastq_1] or [meta, fastq_1, fastq_2] adding id, numLanes and paired_end to meta.
+                    return [ meta + [ id:"${meta.sample}-${meta.lane}", paired_end:fastq_2 ? true : false ], fastq_2 ? [ fastq_1, fastq_2 ] : [ fastq_1 ] ]
+                aln: cram || bam
+                    // return channel [meta, cram, crai] or [meta, bam, bai] adding id, numLanes to metadata.
+                    return [ meta + [id: "${meta.sample}"], cram ? [ cram, crai ] : [ bam, bai ] ]
+                gvcf: gvcf
+                    // return channel [meta, gvcf] adding id to metadata.
+                    return [ meta + [ id:meta.sample ], gvcf]
+            }
 
     emit:
-    samplesheet = ch_samplesheet
+    samplesheet_aln = ch_samplesheet.aln
+    samplesheet_fastq = ch_samplesheet.fastq
+    samplesheet_gvcf = ch_samplesheet.gvcf
     versions    = ch_versions
 }
 

--- a/workflows/qualitycontrol.nf
+++ b/workflows/qualitycontrol.nf
@@ -20,7 +20,10 @@ include { VCF_ID_REPAIR } from '../subworkflows/local/vcf_id_repair/main'
 workflow QUALITYCONTROL {
 
     take:
-    ch_samplesheet // channel: samplesheet read in from --input
+    ch_fastq
+    ch_aln
+    ch_gvcf // channel: samplesheet read in from --input
+
     main:
 
     ch_versions = Channel.empty()


### PR DESCRIPTION
Adding a simple samplesheet parsing to be able to test the subworkflows in the entire pipeline context.

It basically separates the input into 3 channels depending on the type of data, which will be fed to their specific stream.

<!--
# Ferlab-Ste-Justine/quality-control-pipeline pull request

Many thanks for contributing to Ferlab-Ste-Justine/quality-control-pipeline!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/Ferlab-Ste-Justine/quality-control-pipeline/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/Ferlab-Ste-Justine/quality-control-pipeline/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
