### PR TITLE
fix: BIOINFO-168 Fix sample name and default value in multiqc report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased - [10/04/2026]
 
+### `Fixed`
+[#33](https://github.com/Ferlab-Ste-Justine/quality-control-pipeline/pull/33) Fixed sample name parsing in picard and verifybamID multiqc modules. Removed default of 0 when value is None.
+
+
+## v0.0.2dev - [10/04/2026]
+
 ### `Added`
 [#30](https://github.com/Ferlab-Ste-Justine/quality-control-pipeline/pull/30) Added pipeline documentation and refactor configs.
 
@@ -18,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 [#31](https://github.com/Ferlab-Ste-Justine/quality-control-pipeline/pull/31) Fixed bug when processing without specified coverage regions.
 
-## v1.0.0dev - [26/09/2025]
+## v0.0.1dev - [26/09/2025]
 
 ### `Added`
 - [#28](https://github.com/Ferlab-Ste-Justine/quality-control-pipeline/pull/28) Added first version of multiqc report and gathering of VCF stats.

--- a/assets/multiqc_config.yml
+++ b/assets/multiqc_config.yml
@@ -45,6 +45,10 @@ remove_sections:
   - 'samtools-percent-mapped'
   - 'mosdepth-xy-coverage'
 
+use_filename_as_sample_name:
+  - picard
+  - verifybamid
+
 preserve_module_raw_data: true
 disable_version_detection: true
 show_analysis_paths: false

--- a/modules/local/multiqc_python/resources/usr/bin/multiqc_report.py
+++ b/modules/local/multiqc_python/resources/usr/bin/multiqc_report.py
@@ -17,10 +17,6 @@ import json
 # Initialise the logger
 log = logging.getLogger('multiqc')
 
-def _num(v, default=0):
-    """Return numeric value or default if None or not set."""
-    return default if v is None else v
-
 def get_alignment_and_pedigree_data():
     """Retrieve alignment and pedigree data from MultiQC's parsed data.
 
@@ -62,18 +58,19 @@ def get_alignment_and_pedigree_data():
                 continue
             for s_name, data in pdata.items():
                 s_name = _clean_sample_name(s_name)
-                print(s_name)
                 if not isinstance(data, dict) or 'MEAN_COVERAGE' not in data:
                     continue
                 mc = data.get('MEAN_COVERAGE')
                 mc = float(mc) if mc is not None else None
                 sd = data.get('SD_COVERAGE')
                 sd = float(sd) if sd is not None else None
+                mad = data.get('MAD_COVERAGE')
+                mad = float(mad) if mad is not None else None
                 p15 = data.get('PCT_15X') or data.get('PCT_15X')
                 p15 = float(p15) if p15 is not None else None
                 alignment_stats_data[s_name].update({
                     'mean_autosome_coverage': mc,
-                    'mad_autosome_coverage': sd,
+                    'mad_autosome_coverage': mad,
                     'pct_autosomes_15x': p15,
                 })
 
@@ -203,9 +200,9 @@ def add_general_status_section(module, alignment_stats_data, qc_thresholds, pedi
     status_data = {}
     for s_name in sorted(samples):
         data = alignment_stats_data.get(s_name, {})
-        pct_mapped = _num(data.get('pct_reads_mapped')) if data else None
-        pct_proper = _num(data.get('pct_reads_properly_paired')) if data else None
-        contam = _num(data.get('cross_contamination_rate')) if data else None
+        pct_mapped = data.get('pct_reads_mapped') if data else None
+        pct_proper = data.get('pct_reads_properly_paired') if data else None
+        contam = data.get('cross_contamination_rate') if data else None
         # Preserve None for missing mean coverage (don't default to 0.0X)
         mean_cov = data.get('mean_autosome_coverage') if data else None
 
@@ -228,7 +225,7 @@ def add_general_status_section(module, alignment_stats_data, qc_thresholds, pedi
             if vm is None:
                 vcf_quality = 'na'
             else:
-                total_snvs = _num(vm.get('total_snvs'), 0)
+                total_snvs = vm.get('total_snvs')
                 vcf_quality = 'pass' if total_snvs > 0 else 'fail'
 
         # If there were pedigree comparisons available for this sample, use pass/fail.
@@ -383,10 +380,10 @@ def add_gene_coverage_section(gene_coverage_data):
         rows[key] = {
             'sample': sample,
             'gene': gene,
-            'average_coverage': _num(rec.get('average_coverage')),
-            'coverage15': _num(rec.get('coverage15')),
-            'coverage30': _num(rec.get('coverage30')),
-            'coverage100': _num(rec.get('coverage100')),
+            'average_coverage': rec.get('average_coverage'),
+            'coverage15': rec.get('coverage15'),
+            'coverage30': rec.get('coverage30'),
+            'coverage100': rec.get('coverage100'),
         }
 
     # Build an HTML table so custom JS can search by gene (avoid automatic violin rendering)
@@ -554,7 +551,7 @@ def add_qc_metrics_module(module, alignment_stats_data, variant_metrics_data):
             key = sid
             row = {'sample': sid}
             for k, _ in fields:
-                row[k] = _num(rec.get(k))
+                row[k] = rec.get(k)
             rows[key] = row
 
         headers = {'sample': {'title': 'Sample', 'description': 'Sample ID'}}


### PR DESCRIPTION
<!--
# Ferlab-Ste-Justine/quality-control-pipeline pull request

Many thanks for contributing to Ferlab-Ste-Justine/quality-control-pipeline!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/Ferlab-Ste-Justine/quality-control-pipeline/tree/master/.github/CONTRIBUTING.md)
-->

Multiqc modules picard and verifybamID parse the sample name from the input file, generating discrepancies between the final sample name in the modules. Using option `use_filename_as_sample_name` to retrieve the final SN from the filename in these modules. 
This error uncovered another small bug so I am also fixing that -> removing an internal function that defaulted None values to 0 to get NA instead of a wrong pass/fail value in the report when metric was not calculated.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/Ferlab-Ste-Justine/quality-control-pipeline/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
