### PR TITLE
fix: BIOINFO-172 fix error when no ped file is passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased - [10/04/2026]
+## Unreleased
+
+### `Fixed`
+[#34](https://github.com/Ferlab-Ste-Justine/quality-control-pipeline/pull/34) Fixed issue with ped file channel initialization.
+
+## v0.0.3dev - [10/04/2026]
 
 ### `Fixed`
 [#33](https://github.com/Ferlab-Ste-Justine/quality-control-pipeline/pull/33) Fixed sample name parsing in picard and verifybamID multiqc modules. Removed default of 0 when value is None.

--- a/subworkflows/local/cram_somalier/main.nf
+++ b/subworkflows/local/cram_somalier/main.nf
@@ -15,9 +15,9 @@ workflow CRAM_SOMALIER {
         ch_peds                 // channel: [mandatory] [ val(meta), path(ped) ]
         ch_sample_groups        // channel: [optional]  [ path(txt) ]
         val_common_id           // string:  [optional]  A common identifier for the samples that need to be related. - Family ID for example
-        
+
     main:
-    
+
     ch_versions = Channel.empty()
 
     ch_input = ch_crams
@@ -27,14 +27,14 @@ workflow CRAM_SOMALIER {
             no_crai: crai == []
                 return [ meta, cram ]
         }
-    
+
     SAMTOOLS_INDEX ( ch_input.no_crai )
     ch_versions = ch_versions.mix(SAMTOOLS_INDEX.out.versions.first())
 
     ch_somalierextract_input = ch_input.no_crai
         .join(SAMTOOLS_INDEX.out.crai) //.bai
         .mix(ch_input.crai)
-        .map { meta, cram, crai -> 
+        .map { meta, cram, crai ->
             [ meta, cram, crai, meta.samplename_somalier ]
         }
 
@@ -56,7 +56,7 @@ workflow CRAM_SOMALIER {
                 def new_meta = val_common_id ? meta + [id:meta[val_common_id]] : meta
                 [ count ? groupKey(new_meta, count): new_meta, extract ]
             }
-            .groupTuple()        
+            .groupTuple()
             .join(ch_peds, failOnDuplicate: true, failOnMismatch: true)
             .map { meta, extract, ped ->
                 def extract2 = extract[0] instanceof ArrayList ? extract[0] : extract
@@ -64,13 +64,13 @@ workflow CRAM_SOMALIER {
                 def new_meta = meta instanceof nextflow.extension.GroupKey ? meta.target : meta
                 [ new_meta, sorted_extract, ped ]
             } // Sort and flatten the extract list, remove the GroupKey wrapper if present
-    } 
+    }
     else {
         ch_somalierrelate_input = SOMALIER_EXTRACT.out.extract
-            .map { meta, extract_path -> extract_path}
+            .map { _meta, extract_path -> extract_path}
             .collect()
             .map { paths_list -> [ [id: 'Cohort'], paths_list ] }
-            .combine(ch_peds.map { meta, ped -> ped  })
+            .combine(ch_peds.map { _meta, ped -> ped }.toList())
     }
 
     SOMALIER_RELATE(

--- a/workflows/qualitycontrol.nf
+++ b/workflows/qualitycontrol.nf
@@ -44,7 +44,7 @@ workflow QUALITYCONTROL {
 
     // somalier sites VCF
     ch_somalier_sites = params.somalier_sites ? channel.value(file(params.somalier_sites, checkIfExists:true)) : channel.value([])
-    ch_ped = params.ped_file ? channel.value(file(params.ped_file, checkIfExists:true)) : channel.of([])
+    ch_ped = params.ped_file ? channel.value(file(params.ped_file, checkIfExists:true)) : channel.value([])
     // verifybamid SVD files
     ch_svd_ud  = params.verifybamid_svd_prefix ? channel.value(file(params.verifybamid_svd_prefix + '.UD', checkIfExists:true)) : channel.value([])
     ch_svd_mu  = params.verifybamid_svd_prefix ? channel.value(file(params.verifybamid_svd_prefix + '.mu', checkIfExists:true)) : channel.value([])


### PR DESCRIPTION
<!--
# Ferlab-Ste-Justine/quality-control-pipeline pull request

Many thanks for contributing to Ferlab-Ste-Justine/quality-control-pipeline!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/Ferlab-Ste-Justine/quality-control-pipeline/tree/master/.github/CONTRIBUTING.md)
-->
Fixed somalier input channel throwing an error if no ped file was passed as input.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/Ferlab-Ste-Justine/quality-control-pipeline/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
