### PR TITLE
feat: BIOINFO-176 Allow to build pedigree from samplesheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 [#36](https://github.com/Ferlab-Ste-Justine/quality-control-pipeline/pull/36) Added test profile
+[#38](https://github.com/Ferlab-Ste-Justine/quality-control-pipeline/pull/38) Added new samplesheet fields: `relationship_to_proband` and `affected_status` and feature to generate pedigree file from samplesheet.
 
 ## v0.0.3dev - [10/04/2026]
 

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -47,6 +47,20 @@
                 "minimum": 0,
                 "maximum": 1
             },
+            "relationship_to_proband": {
+                "errorMessage": "Relationship to proband. Defaults to Proband if not provided.",
+                "meta": ["relationship_to_proband"],
+                "default": "Proband",
+                "type": "string",
+                "enum": ["Proband", "Mother", "Father", "Brother", "Sister", "Half-brother", "Half-sister", "Identical twin", "Fraternal twin brother", "Fraternal twin sister", "Son", "Daughter", "Other", "Fetus"]
+            },
+            "affected_status": {
+                "errorMessage": "Affected status. Must be one of: Affected, Unaffected, Unknown. Defaults to Unknown.",
+                "meta": ["affected_status"],
+                "default": "Unknown",
+                "type": "string",
+                "enum": ["Affected", "Unaffected", "Unknown"]
+            },
             "lane": {
                 "type": "string",
                 "pattern": "^\\S+$",

--- a/subworkflows/local/utils_nfcore_quality-control-pipeline_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_quality-control-pipeline_pipeline/main.nf
@@ -106,7 +106,7 @@ workflow PIPELINE_INITIALISATION {
             }
             [ meta, [file1, file2] ]
         }
-        
+
     emit:
     samplesheet = ch_samplesheet
     versions    = ch_versions
@@ -189,6 +189,82 @@ def findIndex(fileType, dataFile) {
         return []
     }
     return file(index)
+}
+
+//
+// Build PED rows for one family from samplesheet meta. Returns a list of
+// [filename, tsv_line] tuples suitable for collectFile. In a prenatal trio
+// (Mother/Father/Fetus, no Proband row) the Mother row is the proband biologically;
+// Mother/Father still resolve to parents=0, and Fetus links to the family's
+// Father/Mother rows — same as any other child relationship.
+//
+def buildPedRowsForFamily(familyId, metas, perFamily) {
+    // Anchor parent/proband lookups to the primary sample row (sample_idx == 0),
+    // whose samplename_somalier equals meta.sample.
+    def fatherRow  = metas.find { m -> m.relationship_to_proband == 'Father'  && (m.sample_idx ?: 0) == 0 }
+    def motherRow  = metas.find { m -> m.relationship_to_proband == 'Mother'  && (m.sample_idx ?: 0) == 0 }
+    def probandRow = metas.find { m -> m.relationship_to_proband == 'Proband' && (m.sample_idx ?: 0) == 0 }
+
+    def fatherId  = fatherRow?.samplename_somalier  ?: '0'
+    def motherId  = motherRow?.samplename_somalier  ?: '0'
+    def probandId = probandRow?.samplename_somalier ?: '0'
+    def probandSex = probandRow?.sex
+
+    def filename = perFamily ? "${familyId}.ped".toString() : 'Cohort.ped'
+
+    return metas.collect { m ->
+        def rel = m.relationship_to_proband ?: 'Proband'
+        def parents = pedParentsFor(rel, fatherId, motherId, probandId, probandSex)
+        def sex = sexForPed(m, rel)
+        def phenotype = phenotypeForPed(m.affected_status)
+        def line = [familyId, m.samplename_somalier, parents[0], parents[1], sex, phenotype].join('\t')
+        [ filename, line ]
+    }
+}
+
+//
+// Map (relationship, family context) to [paternal_id, maternal_id].
+//
+def pedParentsFor(rel, fatherId, motherId, probandId, probandSex) {
+    // These all link to the family's Father/Mother rows (proband, full siblings and twins
+    // share both parents; the fetus links to its Mother/Father rows).
+    def is_child = ['Proband', 'Fetus', 'Brother', 'Sister',
+        'Identical twin', 'Fraternal twin brother', 'Fraternal twin sister']
+    if (rel in is_child) {
+        return [fatherId, motherId]
+    }
+    if (rel == 'Son' || rel == 'Daughter') {
+        if (probandSex == 'Male')   { return [probandId, '0'] }
+        if (probandSex == 'Female') { return ['0', probandId] }
+        return ['0', '0']
+    }
+    // Father, Mother, Half-brother, Half-sister, Other, null
+    return ['0', '0']
+}
+
+//
+// PED sex code from samplesheet, warning if it disagrees with the relationship label.
+//
+def sexForPed(meta, rel) {
+    def relationshipsBySex = [
+        'Male'   : ['Father', 'Brother', 'Half-brother', 'Fraternal twin brother', 'Son'],
+        'Female' : ['Mother', 'Sister', 'Half-sister', 'Fraternal twin sister', 'Daughter'],
+    ]
+    // Relationships not listed (Proband, Fetus, Identical twin, Other) imply no fixed sex.
+    def expected = relationshipsBySex.find { entry -> rel in entry.value }?.key
+    if (expected && meta.sex && meta.sex != 'NA' && meta.sex != expected) {
+        log.warn("Sample ${meta.samplename_somalier}: relationship '${rel}' expects sex=${expected} but samplesheet has '${meta.sex}'. Using samplesheet sex.")
+    }
+    return meta.sex == 'Female' ? 2 : (meta.sex == 'Male' ? 1 : 0)
+}
+
+//
+// PED phenotype code from affected_status.
+//
+def phenotypeForPed(status) {
+    if (status == 'Affected')   { return 2 }
+    if (status == 'Unaffected') { return 1 }
+    return 0
 }
 
 //

--- a/subworkflows/local/utils_nfcore_quality-control-pipeline_pipeline/tests/main.function.nf.test
+++ b/subworkflows/local/utils_nfcore_quality-control-pipeline_pipeline/tests/main.function.nf.test
@@ -1,0 +1,281 @@
+nextflow_function {
+
+    name "Test pedigree helper functions"
+    script "../main.nf"
+    tag "subworkflows"
+    tag "subworkflows_local"
+    tag "utils_nfcore_quality-control-pipeline_pipeline"
+
+    //
+    // phenotypeForPed
+    //
+    test("phenotypeForPed: Affected -> 2") {
+        function "phenotypeForPed"
+        when { function { "input[0] = 'Affected'" } }
+        then { assertAll(
+            { assert function.success },
+            { assert function.result == 2 }
+        ) }
+    }
+
+    test("phenotypeForPed: Unaffected -> 1") {
+        function "phenotypeForPed"
+        when { function { "input[0] = 'Unaffected'" } }
+        then { assertAll(
+            { assert function.success },
+            { assert function.result == 1 }
+        ) }
+    }
+
+    test("phenotypeForPed: Unknown -> 0") {
+        function "phenotypeForPed"
+        when { function { "input[0] = 'Unknown'" } }
+        then { assertAll(
+            { assert function.success },
+            { assert function.result == 0 }
+        ) }
+    }
+
+    test("phenotypeForPed: null/unrecognised -> 0") {
+        function "phenotypeForPed"
+        when { function { "input[0] = null" } }
+        then { assertAll(
+            { assert function.success },
+            { assert function.result == 0 }
+        ) }
+    }
+
+    //
+    // pedParentsFor  (rel, fatherId, motherId, probandId, probandSex)
+    //
+    test("pedParentsFor: Proband links to both parents") {
+        function "pedParentsFor"
+        when { function { """
+            input[0] = 'Proband'
+            input[1] = 'DAD'
+            input[2] = 'MOM'
+            input[3] = 'PRO'
+            input[4] = 'Female'
+        """ } }
+        then { assertAll(
+            { assert function.success },
+            { assert function.result == ['DAD', 'MOM'] }
+        ) }
+    }
+
+    test("pedParentsFor: Fetus links to both parents (no Proband row)") {
+        function "pedParentsFor"
+        when { function { """
+            input[0] = 'Fetus'
+            input[1] = 'DAD'
+            input[2] = 'MOM'
+            input[3] = '0'
+            input[4] = null
+        """ } }
+        then { assertAll(
+            { assert function.success },
+            { assert function.result == ['DAD', 'MOM'] }
+        ) }
+    }
+
+    test("pedParentsFor: sibling links to both parents") {
+        function "pedParentsFor"
+        when { function { """
+            input[0] = 'Brother'
+            input[1] = 'DAD'
+            input[2] = 'MOM'
+            input[3] = 'PRO'
+            input[4] = 'Female'
+        """ } }
+        then { assertAll(
+            { assert function.success },
+            { assert function.result == ['DAD', 'MOM'] }
+        ) }
+    }
+
+    test("pedParentsFor: Son of a male proband -> proband is the father") {
+        function "pedParentsFor"
+        when { function { """
+            input[0] = 'Son'
+            input[1] = '0'
+            input[2] = '0'
+            input[3] = 'PRO'
+            input[4] = 'Male'
+        """ } }
+        then { assertAll(
+            { assert function.success },
+            { assert function.result == ['PRO', '0'] }
+        ) }
+    }
+
+    test("pedParentsFor: Daughter of a female proband -> proband is the mother") {
+        function "pedParentsFor"
+        when { function { """
+            input[0] = 'Daughter'
+            input[1] = '0'
+            input[2] = '0'
+            input[3] = 'PRO'
+            input[4] = 'Female'
+        """ } }
+        then { assertAll(
+            { assert function.success },
+            { assert function.result == ['0', 'PRO'] }
+        ) }
+    }
+
+    test("pedParentsFor: child of unknown-sex proband -> no parents") {
+        function "pedParentsFor"
+        when { function { """
+            input[0] = 'Son'
+            input[1] = '0'
+            input[2] = '0'
+            input[3] = 'PRO'
+            input[4] = 'NA'
+        """ } }
+        then { assertAll(
+            { assert function.success },
+            { assert function.result == ['0', '0'] }
+        ) }
+    }
+
+    test("pedParentsFor: Father/Mother/half-sibling/Other have no parents") {
+        function "pedParentsFor"
+        when { function { """
+            input[0] = 'Half-brother'
+            input[1] = 'DAD'
+            input[2] = 'MOM'
+            input[3] = 'PRO'
+            input[4] = 'Male'
+        """ } }
+        then { assertAll(
+            { assert function.success },
+            { assert function.result == ['0', '0'] }
+        ) }
+    }
+
+    //
+    // sexForPed  (meta, rel)
+    //
+    test("sexForPed: Female -> 2") {
+        function "sexForPed"
+        when { function { """
+            input[0] = [ sex: 'Female', samplename_somalier: 'S1' ]
+            input[1] = 'Mother'
+        """ } }
+        then { assertAll(
+            { assert function.success },
+            { assert function.result == 2 }
+        ) }
+    }
+
+    test("sexForPed: Male -> 1") {
+        function "sexForPed"
+        when { function { """
+            input[0] = [ sex: 'Male', samplename_somalier: 'S1' ]
+            input[1] = 'Father'
+        """ } }
+        then { assertAll(
+            { assert function.success },
+            { assert function.result == 1 }
+        ) }
+    }
+
+    test("sexForPed: NA/unknown -> 0") {
+        function "sexForPed"
+        when { function { """
+            input[0] = [ sex: 'NA', samplename_somalier: 'S1' ]
+            input[1] = 'Proband'
+        """ } }
+        then { assertAll(
+            { assert function.success },
+            { assert function.result == 0 }
+        ) }
+    }
+
+    test("sexForPed: relationship/sex mismatch still uses samplesheet sex") {
+        function "sexForPed"
+        when { function { """
+            input[0] = [ sex: 'Female', samplename_somalier: 'S1' ]
+            input[1] = 'Brother'
+        """ } }
+        then { assertAll(
+            { assert function.success },
+            { assert function.result == 2 }
+        ) }
+    }
+
+    //
+    // buildPedRowsForFamily  (familyId, metas, perFamily)
+    //
+    test("buildPedRowsForFamily: per-family trio") {
+        function "buildPedRowsForFamily"
+        when { function { """
+            input[0] = 'FAM1'
+            input[1] = [
+                [ samplename_somalier: 'CHILD', relationship_to_proband: 'Proband', sample_idx: 0, sex: 'Female', affected_status: 'Affected'   ],
+                [ samplename_somalier: 'DAD',   relationship_to_proband: 'Father',  sample_idx: 0, sex: 'Male',   affected_status: 'Unaffected' ],
+                [ samplename_somalier: 'MOM',   relationship_to_proband: 'Mother',  sample_idx: 0, sex: 'Female', affected_status: 'Unaffected' ],
+            ]
+            input[2] = true
+        """ } }
+        then { assertAll(
+            { assert function.success },
+            { assert function.result == [
+                [ 'FAM1.ped', "FAM1\tCHILD\tDAD\tMOM\t2\t2" ],
+                [ 'FAM1.ped', "FAM1\tDAD\t0\t0\t1\t1" ],
+                [ 'FAM1.ped', "FAM1\tMOM\t0\t0\t2\t1" ],
+            ] }
+        ) }
+    }
+
+    test("buildPedRowsForFamily: cohort mode writes Cohort.ped") {
+        function "buildPedRowsForFamily"
+        when { function { """
+            input[0] = 'FAM1'
+            input[1] = [
+                [ samplename_somalier: 'S1', relationship_to_proband: 'Proband', sample_idx: 0, sex: 'Male', affected_status: 'Unknown' ],
+            ]
+            input[2] = false
+        """ } }
+        then { assertAll(
+            { assert function.success },
+            { assert function.result == [ [ 'Cohort.ped', "FAM1\tS1\t0\t0\t1\t0" ] ] }
+        ) }
+    }
+
+    test("buildPedRowsForFamily: prenatal trio (Mother is proband, Fetus links to parents)") {
+        function "buildPedRowsForFamily"
+        when { function { """
+            input[0] = 'FAM2'
+            input[1] = [
+                [ samplename_somalier: 'MOM',   relationship_to_proband: 'Mother', sample_idx: 0, sex: 'Female',  affected_status: 'Unaffected' ],
+                [ samplename_somalier: 'DAD',   relationship_to_proband: 'Father', sample_idx: 0, sex: 'Male',    affected_status: 'Unaffected' ],
+                [ samplename_somalier: 'FETUS', relationship_to_proband: 'Fetus',  sample_idx: 0, sex: 'NA',      affected_status: 'Affected'   ],
+            ]
+            input[2] = true
+        """ } }
+        then { assertAll(
+            { assert function.success },
+            { assert function.result == [
+                [ 'FAM2.ped', "FAM2\tMOM\t0\t0\t2\t1" ],
+                [ 'FAM2.ped', "FAM2\tDAD\t0\t0\t1\t1" ],
+                [ 'FAM2.ped', "FAM2\tFETUS\tDAD\tMOM\t0\t2" ],
+            ] }
+        ) }
+    }
+
+    test("buildPedRowsForFamily: solo sample with no relationship defaults to proband, no parents") {
+        function "buildPedRowsForFamily"
+        when { function { """
+            input[0] = 'SOLO'
+            input[1] = [
+                [ samplename_somalier: 'X', relationship_to_proband: null, sample_idx: 0, sex: 'Female', affected_status: 'Unknown' ],
+            ]
+            input[2] = true
+        """ } }
+        then { assertAll(
+            { assert function.success },
+            { assert function.result == [ [ 'SOLO.ped', "SOLO\tX\t0\t0\t2\t0" ] ] }
+        ) }
+    }
+}

--- a/workflows/qualitycontrol.nf
+++ b/workflows/qualitycontrol.nf
@@ -8,6 +8,7 @@ include { paramsSummaryMap       } from 'plugin/nf-schema'
 include { paramsSummaryMultiqc   } from '../subworkflows/nf-core/utils_nfcore_pipeline'
 include { softwareVersionsToYAML } from '../subworkflows/nf-core/utils_nfcore_pipeline'
 include { methodsDescriptionText } from '../subworkflows/local/utils_nfcore_quality-control-pipeline_pipeline'
+include { buildPedRowsForFamily  } from '../subworkflows/local/utils_nfcore_quality-control-pipeline_pipeline'
 include { FASTQ_QC               } from '../subworkflows/local/fastq_qc/main'
 include { BAM_QC as BAM_QC_WGS   } from '../subworkflows/local/bam_qc/main'
 include { BAM_QC as BAM_QC_TARGET   } from '../subworkflows/local/bam_qc/main'
@@ -92,7 +93,7 @@ workflow QUALITYCONTROL {
     //
     bam_to_merge = ch_samplesheet_parsed.aln
         .map { meta, cram, crai ->
-        [ groupKey(meta.subMap('id', 'participant', 'sample', 'familyId', 'sex', 'sequencingType', 'status'), meta.n_lanes), cram, crai ]
+        [ groupKey(meta.subMap('id', 'participant', 'sample', 'familyId', 'sex', 'sequencingType', 'status', 'relationship_to_proband', 'affected_status'), meta.n_lanes), cram, crai ]
     }
     .groupTuple()
 
@@ -172,20 +173,44 @@ workflow QUALITYCONTROL {
             "${samples.join(',')}\n"
         }
         .ifEmpty{[]}
+        .first()  // value channel so the single sample_groups file is reused across every per-family relate
         .set{ch_sample_groups}
 
-    ch_somalier_input_ped =  ch_ped.map { it -> [ [id:"ped"], it ] }
+    //
+    // Build pedigree input for somalier.
+    //   1. If params.ped_file is set, use it (split per-family when somalier_perfamily).
+    //   2. Otherwise derive from samplesheet meta (relationship_to_proband, affected_status, sex).
+    //      Missing relationship_to_proband defaults to "Proband" with parents=0, so cohorts of
+    //      solo samples and singletons fall out of the same logic.
+    //
+    def pedHeader = ['#family_id','name','paternal_id','maternal_id','sex','phenotype'].join('\t')
 
-    // If we want to run the analysis in a per-family basis or with the entire cohort
-    if (params.somalier_perfamily) {
-        def pedHeader = ['#family_id','name','paternal_id','maternal_id','sex','phenotype'].join('\t')
-        ch_somalier_input_ped = ch_ped
-            .splitCsv(sep: '\t', header: ["family_id","name","paternal_id","maternal_id","sex","phenotype"], skip: 1)
-            .map { row ->
-                def line = [row.family_id, row.name, row.paternal_id, row.maternal_id, row.sex, row.phenotype].join('\t')
-                [ "${row.family_id}.ped".toString(), line ]
+    if (params.ped_file) {
+        if (params.somalier_perfamily) {
+            ch_somalier_input_ped = ch_ped
+                .splitCsv(sep: '\t', header: ["family_id","name","paternal_id","maternal_id","sex","phenotype"], skip: 1)
+                .map { row ->
+                    def line = [row.family_id, row.name, row.paternal_id, row.maternal_id, row.sex, row.phenotype].join('\t')
+                    [ "${row.family_id}.ped".toString(), line ]
+                }
+                .collectFile(
+                    newLine: true,
+                    sort: true,
+                    seed: pedHeader
+                )
+                .map { ped_file -> [ [id: ped_file.baseName], ped_file ] }
+        } else {
+            ch_somalier_input_ped = ch_ped.map { it -> [ [id:"ped"], it ] }
+        }
+    } else {
+        ch_somalier_input_ped = ch_cram_crai_somalier
+            .map { meta, _cram, _crai, _count -> [meta.familyId, meta] }
+            .groupTuple()
+            .flatMap { familyId, metas ->
+                buildPedRowsForFamily(familyId, metas, params.somalier_perfamily as boolean)
             }
             .collectFile(
+                storeDir: "${params.outdir}/reports/pedigree",
                 newLine: true,
                 sort: true,
                 seed: pedHeader


### PR DESCRIPTION
<!--
# Ferlab-Ste-Justine/quality-control-pipeline pull request

Many thanks for contributing to Ferlab-Ste-Justine/quality-control-pipeline!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/Ferlab-Ste-Justine/quality-control-pipeline/tree/master/.github/CONTRIBUTING.md)
-->

Added two fields to the samplesheet: `relationship_to_proband` and `affected_status`. Following Radiants and CQDG dictionary. 

If no ped file is provided, it will get generated from the samplesheet. 
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/Ferlab-Ste-Justine/quality-control-pipeline/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
